### PR TITLE
Add colored output on Windows

### DIFF
--- a/wmlxgettext/pywmlx/__init__.py
+++ b/wmlxgettext/pywmlx/__init__.py
@@ -1,4 +1,5 @@
 from pywmlx.wmlerr import ansi_setEnabled
+from pywmlx.wmlerr import wincol_setEnabled
 from pywmlx.wmlerr import wmlerr
 from pywmlx.wmlerr import wmlwarn
 from pywmlx.wmlerr import set_warnall

--- a/wmlxgettext/pywmlx/wmlerr.py
+++ b/wmlxgettext/pywmlx/wmlerr.py
@@ -38,11 +38,9 @@ class WmlWarning(UserWarning):
 
 
 def print_wmlerr(message, iserr):
-    ansi_color = '\033[91;1m'  #red
-    errtype = "error:"
-    if iserr is False:
-        ansi_color = '\033[94m'  #blue
-        errtype = "warning:"
+    # red if error, blue if warning
+    ansi_color = '\033[91;1m' if iserr else '\033[94m'
+    errtype = "error:" if iserr else "warning:"
     # now we have ascii_color and errtype values
     # here we print the error/warning. 
     # 1) On posix we write "error" in red and "warning" in blue

--- a/wmlxgettext/pywmlx/wmlerr.py
+++ b/wmlxgettext/pywmlx/wmlerr.py
@@ -1,10 +1,26 @@
 import os
 import sys
 import warnings
+import ctypes
+import struct
 
 enabled_ansi_col = True
 is_utest = False
 _warnall = False
+
+
+# these constants are used by the Win32 API
+FG_RED = 4
+FG_GREEN = 2
+FG_BLUE = 1
+FG_INTENSITY = 8
+BG_RED = 64
+BG_GREEN = 32
+BG_BLUE = 16
+BG_INTENSITY = 128
+STD_INPUT_HANDLE = -10
+STD_OUTPUT_HANDLE = -11
+STD_ERROR_HANDLE = -12
 
 
 def wmlerr_debug():

--- a/wmlxgettext/wmlxgettext.py
+++ b/wmlxgettext/wmlxgettext.py
@@ -102,6 +102,14 @@ def commandline(args):
               ' disabled).')
     )
     parser.add_argument(
+        '--win-colors',
+        action='store_true',
+        default=False,
+        dest='win_col',
+        help=("On Windows systems, this flag uses the Win32 API to colorize "
+              "the output.")
+    )
+    parser.add_argument(
         '--warnall',
         action='store_true',
         default=False,
@@ -138,6 +146,7 @@ def commandline(args):
 def main():
     args = commandline(sys.argv[1:])
     pywmlx.ansi_setEnabled(args.ansi_col)
+    pywmlx.wincol_setEnabled(args.win_col)
     pywmlx.set_warnall(args.warnall)
     startPath = os.path.realpath(os.path.normpath(args.start_path))
     sentlist = dict()


### PR DESCRIPTION
This PR adds support to colored stderr messages on Windows. This is done by using the Win32 API through the `ctypes` and `struct` libraries (both are included in Python's standard library).
In order to do this, I had to remove the `dualcol_message()` function, and merge its content with the `print_wmlerr()` function. I also added a new command line switch, called `--win-colors`, which defaults to `False` and allows using the Windows-specific code.
